### PR TITLE
give fenrir full xray permissions to allow actions like PutTraceSegments

### DIFF
--- a/resources/assumed_policy.json.erb
+++ b/resources/assumed_policy.json.erb
@@ -19,7 +19,8 @@
                 "lambda:*",
                 "apigateway:*",
                 "cloudformation:*",
-                "events:*"
+                "events:*",
+                "xray:*"
             ],
             "Resource": "*"
         },


### PR DESCRIPTION
creating a function with `Tracing: Active` returns the error:

```
The provided execution role does not have permissions to call PutTraceSegments on XRAY (Service: AWSLambdaInternal; Status Code: 400; Error Code: InvalidParameterValueException; Request ID: 8bfbd397-469c-11e9-be15-b13440732b8b)
```