### PR TITLE
[fix] check tags on DynamoDB table itself, since streams do not have tags

### DIFF
--- a/deployer/template/aws_serverless_function_events.go
+++ b/deployer/template/aws_serverless_function_events.go
@@ -78,8 +78,11 @@ func ValidateKinesisEvent(projectName, configName string, event *resources.AWSSe
 }
 
 func ValidateDynamoDBEvent(projectName, configName string, event *resources.AWSServerlessFunction_DynamoDBEvent, ddbc aws.DDBAPI) error {
+	// we want to check the tags on the table itself, streams do not have tags
+	dynamodbStreamName := strings.SplitN(event.Stream, "/stream", 3)[0]
+
 	out, err := ddbc.ListTagsOfResource(&dynamodb.ListTagsOfResourceInput{
-		ResourceArn: to.Strp(event.Stream),
+		ResourceArn: to.Strp(dynamodbStreamName),
 	})
 
 	if err != nil {


### PR DESCRIPTION
**What changed? Why?**
Fenrir tries to check the tags of the DynamoDB stream (but streams can't have tags). Instead check the DynamoDB Table for the tags.


**How has it been tested?**
locally

**Change management**
type=routine
risk=low
impact=sev5