### PR TITLE
Fix: Normalize IAM Action and principals

### DIFF
--- a/aws/iam/policy.go
+++ b/aws/iam/policy.go
@@ -1,0 +1,47 @@
+package iam
+
+// normalizeInterfaceToStringArr normalizes a single string or []string to []string
+func normalizeInterfaceToStringArr(inter interface{}) []string {
+	var sArr []string
+
+	switch inter.(type) {
+	case string:
+		sArr = []string{inter.(string)}
+	case []interface{}:
+		sInters := inter.([]interface{})
+
+		for _, i := range sInters {
+			s, ok := i.(string)
+			if ok {
+				sArr = append(sArr, s)
+			}
+		}
+	}
+
+	return sArr
+}
+
+type PolicyDocument struct {
+	Version   string
+	Statement []StatementEntry
+}
+
+type StatementEntry struct {
+	Effect    string
+	Action    interface{}
+	Resource  string
+	Principal PrincipalEntry
+}
+
+func (s StatementEntry) NormalizedAction() []string {
+	return normalizeInterfaceToStringArr(s.Action)
+}
+
+type PrincipalEntry struct {
+	AWS interface{}
+}
+
+// AWS normalizes the string or []string entries in AWS principals.
+func (e PrincipalEntry) NormalizedAWS() []string {
+	return normalizeInterfaceToStringArr(e.AWS)
+}

--- a/aws/mocks/mock_sns.go
+++ b/aws/mocks/mock_sns.go
@@ -19,9 +19,7 @@ var defaultSnsPolicy = `
           "*"
         ]
       },
-      "Action": [
-        "SNS:Subscribe"
-      ],
+      "Action": "SNS:Subscribe",
       "Resource": "arn:aws:sns:us-east-1:000000000000:test-topic",
       "Condition": {
         "StringEquals": {


### PR DESCRIPTION
<!-- Title types: feature | fix | refactor | chore | bug | upgrade | docs -->

**What changed? Why?**

Action entry in the policy statement can be a single string or array of
strings in addition to the AWS principal.

**How has it been tested?**

Test policy statement adjusted.

**Change management**
type=routine
risk=low
impact=sev4