### PR TITLE
[feature] support GetAtt for SQS events

### DIFF
--- a/deployer/template/aws_serverless_function_events.go
+++ b/deployer/template/aws_serverless_function_events.go
@@ -106,6 +106,12 @@ func ValidateDynamoDBEvent(projectName, configName string, event *resources.AWSS
 }
 
 func ValidateSQSEvent(projectName, configName, region, accountId string, event *resources.AWSServerlessFunction_SQSEvent, sqsc aws.SQSAPI) error {
+	// If the event is a valid GetAtt
+	ref, err := decodeGetAtt(event.Queue)
+	if err == nil && len(ref) > 0 {
+		return nil
+	}
+
 	if !strings.HasPrefix(event.Queue, "arn:") {
 		event.Queue = fmt.Sprintf("arn:aws:sqs:%s:%s:%s", region, accountId, event.Queue)
 	}

--- a/deployer/template/intrinsics.go
+++ b/deployer/template/intrinsics.go
@@ -33,3 +33,32 @@ func decodeRef(value string) (string, error) {
 
 	return intrinsic["Ref"], nil
 }
+
+// decodeRef returns the value of a Ref
+func decodeGetAtt(value string) ([]string, error) {
+	// goformation stores intrinsic functions as base64 encoded strings
+	var decoded []byte
+
+	decoded, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		// The string value is not base64 encoded, so it's not an intrinsic so just pass it back
+		return []string{}, fmt.Errorf("Not a Get Attribute")
+	}
+
+	var intrinsic map[string][]string
+	if err := json.Unmarshal([]byte(decoded), &intrinsic); err != nil {
+		// The string value is not JSON, so it's not an intrinsic so just pass it back
+		return []string{}, fmt.Errorf("Not a (or only) a GetAtt")
+	}
+
+	// An intrinsic should be an object, with a single key containing a valid intrinsic name
+	if len(intrinsic) != 1 {
+		return []string{}, fmt.Errorf("Incorrect intrinsic")
+	}
+
+	if len(intrinsic["Fn::GetAtt"]) < 1 {
+		return []string{}, fmt.Errorf("Not a GetAtt")
+	}
+
+	return intrinsic["Fn::GetAtt"], nil
+}

--- a/examples/tests/allowed/sqs_ref_event.yml
+++ b/examples/tests/allowed/sqs_ref_event.yml
@@ -15,7 +15,7 @@ Resources:
         queuelisten:
           Type: SQS
           Properties:
-            Queue: !Ref queue
+            Queue: !GetAtt [queue, arn]
 
   queue:
     Type: AWS::SQS::Queue


### PR DESCRIPTION
<!-- Title types: feature | fix | refactor | chore | bug | upgrade | docs -->

**What changed? Why?**
Referencing just the ARN of an SQS queue works fine... unless you're trying to create the SQS queue alongside the rest of the template.

* Allow SQS events to be created with !GetAtt

**How has it been tested?**
locally and in dev

**Change management**
type=routine
risk=low
impact=sev5