### PR TITLE
set keyId to key.Arn by default

### DIFF
--- a/deployer/template/aws_serverless_function.go
+++ b/deployer/template/aws_serverless_function.go
@@ -150,6 +150,10 @@ func ValidateFunctionIAM(
 				if err != nil {
 					return resourceError(fun, resourceName, fmt.Sprintf("KMSDecryptPolicy %v", err.Error()))
 				}
+
+				// Overwrite keyID to be Key Arn
+				p.KMSDecryptPolicy.KeyId = key.Arn
+
 				err = hasCorrectTags(projectName, configName, key.Tags)
 				if err != nil {
 					return resourceError(fun, resourceName, fmt.Sprintf("KMSDecryptPolicy %v", err.Error()))


### PR DESCRIPTION
<!-- Title types: feature | fix | refactor | chore | bug | upgrade | docs -->

**What changed? Why?**
Key Alias doesn't work in IAM decrypt policies.

**How has it been tested?**
locally, and successfully tested in development

**Change management**
type=routine
risk=low
impact=sev5