### PR TITLE
KMS Policy wants an ID not an ARN

### DIFF
--- a/aws/kms/key.go
+++ b/aws/kms/key.go
@@ -2,6 +2,7 @@ package kms
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/coinbase/fenrir/aws"
@@ -10,7 +11,7 @@ import (
 
 // SecurityGroup struct
 type Key struct {
-	Arn  string
+	Id   string
 	Tags map[string]string
 }
 
@@ -27,8 +28,14 @@ func FindKey(kmsc aws.KMSAPI, keyalias string) (*Key, error) {
 		return nil, fmt.Errorf("Cannot find key %q", keyalias)
 	}
 
+	arnSplit := strings.SplitN(*desc.KeyMetadata.Arn, "/", 2)
+
+	if len(arnSplit) != 2 {
+		return nil, fmt.Errorf("Key incorrect ARN")
+	}
+
 	key := Key{
-		Arn:  *desc.KeyMetadata.Arn,
+		Id:   arnSplit[1],
 		Tags: map[string]string{},
 	}
 

--- a/aws/mocks/mock_kms.go
+++ b/aws/mocks/mock_kms.go
@@ -13,7 +13,7 @@ type KMSClient struct {
 func (m *KMSClient) DescribeKey(in *kms.DescribeKeyInput) (*kms.DescribeKeyOutput, error) {
 	return &kms.DescribeKeyOutput{
 		KeyMetadata: &kms.KeyMetadata{
-			Arn: to.Strp("kms_arn"),
+			Arn: to.Strp("arn:aws:kms:us-east-1:000000000000:key/00000000-0000-0000-0000-000000000000"),
 		},
 	}, nil
 }

--- a/deployer/template/aws_serverless_function.go
+++ b/deployer/template/aws_serverless_function.go
@@ -151,8 +151,8 @@ func ValidateFunctionIAM(
 					return resourceError(fun, resourceName, fmt.Sprintf("KMSDecryptPolicy %v", err.Error()))
 				}
 
-				// Overwrite keyID to be Key Arn
-				p.KMSDecryptPolicy.KeyId = key.Arn
+				// Overwrite keyID to be Key Id (in cases where it was set to an alias)
+				p.KMSDecryptPolicy.KeyId = key.Id
 
 				err = hasCorrectTags(projectName, configName, key.Tags)
 				if err != nil {


### PR DESCRIPTION
<!-- Title types: feature | fix | refactor | chore | bug | upgrade | docs -->

**What changed? Why?**
When passing through an ID to KMSPolicy, it should not be an entire ARN

**How has it been tested?**
Locally

**Change management**
type=routine
risk=low
impact=sev5