### PR TITLE
[feature] add aws::lambda::permission resource

### DIFF
--- a/deployer/integration_test.go
+++ b/deployer/integration_test.go
@@ -84,6 +84,14 @@ var badFiles = []struct {
 		ErrorStr: `AWS::Serverless::Function#hello: VpcConfig Incorrect ProjectName for SecurityGroup: has "bad" requires "project"`,
 	},
 	{
+		File:     "../examples/tests/not/bad_lambda_permission.yml",
+		ErrorStr: `Lambda::Permission.Action must be lambda:InvokeFunction`,
+	},
+	{
+		File:     "../examples/tests/not/bad_lambda_permission_func.yml",
+		ErrorStr: `Lambda::Permission.FunctionName must be "!GetAtt <lambdaName> Arn"`,
+	},
+	{
 		File:     "../examples/tests/not/bad_subnet.yml",
 		ErrorStr: `AWS::Serverless::Function#hello: VpcConfig Validate Subnet Error DeployWithFenrir Tag is nil`,
 	},

--- a/deployer/template/aws_lambda_permission.go
+++ b/deployer/template/aws_lambda_permission.go
@@ -5,16 +5,24 @@ import (
 	"github.com/awslabs/goformation/cloudformation/resources"
 )
 
-// AWS::Lambda::Permission
-
 func ValidateAWSLambdaPermission(
 	projectName, configName, resourceName string,
 	template *cloudformation.Template,
 	res *resources.AWSLambdaPermission,
 ) error {
-	ref, err := decodeRef(res.FunctionName)
-	if err != nil || ref == "" {
-		return resourceError(res, resourceName, "AWS::Lambda::Permission FunctionName must be !Ref")
+	if res.Action != "lambda:InvokeFunction" {
+		return resourceError(res, resourceName, "Lambda::Permission.Action must be lambda:InvokeFunction")
+	}
+
+	// Currently we only allow permissions to grant access to ELB
+	// We can add other things here as we need them
+	if res.Principal != "elasticloadbalancing.amazonaws.com" {
+		return resourceError(res, resourceName, "Lambda::Permission.Principal must be elasticloadbalancing.amazonaws.com")
+	}
+
+	args, err := decodeGetAtt(res.FunctionName)
+	if err != nil || len(args) != 2 || args[1] != "Arn" {
+		return resourceError(res, resourceName, "Lambda::Permission.FunctionName must be \"!GetAtt <lambdaName> Arn\"")
 	}
 
 	return nil

--- a/deployer/template/aws_lambda_permission.go
+++ b/deployer/template/aws_lambda_permission.go
@@ -1,0 +1,21 @@
+package template
+
+import (
+	"github.com/awslabs/goformation/cloudformation"
+	"github.com/awslabs/goformation/cloudformation/resources"
+)
+
+// AWS::Lambda::Permission
+
+func ValidateAWSLambdaPermission(
+	projectName, configName, resourceName string,
+	template *cloudformation.Template,
+	res *resources.AWSLambdaPermission,
+) error {
+	ref, err := decodeRef(res.FunctionName)
+	if err != nil || ref == "" {
+		return resourceError(res, resourceName, "AWS::Lambda::Permission FunctionName must be !Ref")
+	}
+
+	return nil
+}

--- a/deployer/template/validations.go
+++ b/deployer/template/validations.go
@@ -27,6 +27,16 @@ func ValidateTemplateResources(
 
 	for name, a := range template.Resources {
 		switch a.AWSCloudFormationType() {
+		case "AWS::Lambda::Permission":
+			res, err := template.GetAWSLambdaPermissionWithName(name)
+			if err != nil {
+				return err
+			}
+
+			if err := ValidateAWSLambdaPermission(projectName, configName, name, template, res); err != nil {
+				return err
+			}
+
 		case "AWS::Serverless::Function":
 			res, err := template.GetAWSServerlessFunctionWithName(name)
 			if err != nil {

--- a/examples/tests/not/bad_lambda_permission.yml
+++ b/examples/tests/not/bad_lambda_permission.yml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  basicHello:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://bucket/path.zip
+      Handler: hello.lambda
+      Runtime: go1.x
+      Timeout: 5
+      Role: role_correct
+
+  basicHelloPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:GetFunction # Bad permission, we only allow invoke.
+      FunctionName: !GetAtt [basicHello, Arn]
+      Principal: elasticloadbalancing.amazonaws.com

--- a/examples/tests/not/bad_lambda_permission_func.yml
+++ b/examples/tests/not/bad_lambda_permission_func.yml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  basicHello:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://bucket/path.zip
+      Handler: hello.lambda
+      Runtime: go1.x
+      Timeout: 5
+      Role: role_correct
+
+  basicHelloPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+       # Bad FunctionName, we only allow !GetAtt Arn for function in this template.
+      FunctionName: arn:aws:lambda:us-east-1:123456789123:function:coinbase-fenrir
+      Principal: elasticloadbalancing.amazonaws.com


### PR DESCRIPTION
<!-- Title types: feature | fix | refactor | chore | bug | upgrade | docs -->

**What changed? Why?**
Fenrir Lambdas should be able to modify their own function policy. In this case, let a target group outside the template invoke it. 

```
  LambdaInvokePermission:
    Type: AWS::Lambda::Permission
    Properties:
      FunctionName: !GetAtt [basicHello, Arn]
      Action: 'lambda:InvokeFunction'
      Principal: elasticloadbalancing.amazonaws.com
      SourceAccount: !Ref 'AWS::AccountId'
      SourceArn: !Sub arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:targetgroup/tg-test/ed0e8e3912345f5a4
```

AWS::Lambda::Permissions must be !GetAtt

**How has it been tested?**
development, locally.


**Change management**
type=routine
risk=low
impact=sev4