### PR TITLE
[NEW] Allow secretsmanager Lambda Perms

### DIFF
--- a/deployer/template/aws_lambda_permission.go
+++ b/deployer/template/aws_lambda_permission.go
@@ -16,8 +16,8 @@ func ValidateAWSLambdaPermission(
 
 	// Currently we only allow permissions to grant access to ELB
 	// We can add other things here as we need them
-	if res.Principal != "elasticloadbalancing.amazonaws.com" {
-		return resourceError(res, resourceName, "Lambda::Permission.Principal must be elasticloadbalancing.amazonaws.com")
+	if !(res.Principal == "elasticloadbalancing.amazonaws.com" || res.Principal == "secretsmanager.amazonaws.com") {
+		return resourceError(res, resourceName, res.Principal+" is not a currently supported value for Lambda::Permission.Principal")
 	}
 
 	args, err := decodeGetAtt(res.FunctionName)


### PR DESCRIPTION
**What changed? Why?**
This PR allows users to specify secretsmanager as a Principal able to
invoke a Lambda defined in Fenrir.

**How has it been tested?**
- [ ] Development

**Change management**
type=routine
risk=low
impact=sev4