### PR TITLE
[Feature] Add AWS::CloudWatch::Alarm

### DIFF
--- a/deployer/template/aws_cloudwatch_alarm.go
+++ b/deployer/template/aws_cloudwatch_alarm.go
@@ -10,11 +10,11 @@ func ValidateAWSCloudWatchAlarm(
 	template *cloudformation.Template,
 	res *resources.AWSCloudWatchAlarm,
 ) error {
-	if res.MetricName != "" {
+	if res.AlarmName != "" {
 		return resourceError(res, resourceName, "Names are overwritten")
 	}
 
-	res.MetricName = normalizeName("fenrir", projectName, configName, resourceName, 255)
+	res.AlarmName = normalizeName("fenrir", projectName, configName, resourceName, 255)
 
 	return nil
 }

--- a/deployer/template/aws_cloudwatch_alarm.go
+++ b/deployer/template/aws_cloudwatch_alarm.go
@@ -1,0 +1,20 @@
+package template
+
+import (
+	"github.com/awslabs/goformation/cloudformation"
+	"github.com/awslabs/goformation/cloudformation/resources"
+)
+
+func ValidateAWSCloudWatchAlarm(
+	projectName, configName, resourceName string,
+	template *cloudformation.Template,
+	res *resources.AWSCloudWatchAlarm,
+) error {
+	if res.MetricName != "" {
+		return resourceError(res, resourceName, "Names are overwritten")
+	}
+
+	res.MetricName = normalizeName("fenrir", projectName, configName, resourceName, 255)
+
+	return nil
+}

--- a/deployer/template/validations.go
+++ b/deployer/template/validations.go
@@ -90,6 +90,16 @@ func ValidateTemplateResources(
 				return err
 			}
 
+		case "AWS::CloudWatch::Alarm":
+			res, err := template.GetAWSCloudWatchAlarmWithName(name)
+			if err != nil {
+				return err
+			}
+
+			if err := ValidateAWSCloudWatchAlarm(projectName, configName, name, template, res); err != nil {
+				return err
+			}
+
 		case "AWS::ElasticLoadBalancingV2::LoadBalancer":
 			res, err := template.GetAWSElasticLoadBalancingV2LoadBalancerWithName(name)
 			if err != nil {

--- a/examples/tests/allowed/codedeploy_w_alarm.yml
+++ b/examples/tests/allowed/codedeploy_w_alarm.yml
@@ -23,6 +23,7 @@ Resources:
     Properties:
       AlarmDescription: Lambda Function Error > 0
       ComparisonOperator: GreaterThanThreshold
+      MetricName: Errors
       Dimensions:
         - Name: Resource
           Value: !Sub "${hello}:live"

--- a/examples/tests/allowed/codedeploy_w_alarm.yml
+++ b/examples/tests/allowed/codedeploy_w_alarm.yml
@@ -1,0 +1,38 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  hello:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://bucket/path.zip
+      Handler: hello-world
+      Runtime: go1.x
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Type: CodeDeployDefault.LambdaAllAtOnce
+        Role: !Sub arn:aws:iam::${AWS::AccountId}:role/codedeploy-service-role
+      Policies:
+      - LambdaInvokePolicy:
+          FunctionName: !Ref hello
+      - VPCAccessPolicy: {}
+      - KMSDecryptPolicy:
+          KeyId: "alias"
+
+  LatestVersionErrorMetricGreaterThanZeroAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      AlarmDescription: Lambda Function Error > 0
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${hello}:live"
+        - Name: FunctionName
+          Value: !Ref hello 
+        - Name: ExecutedVersion
+          Value: !GetAtt [hello.Version, Version]
+      EvaluationPeriods: 2
+      Namespace: AWS/Lambda
+      Period: 60
+      Statistic: Sum
+      Threshold: 0
+


### PR DESCRIPTION
<!-- Title types: feature | fix | refactor | chore | bug | upgrade | docs -->

**What changed? Why?**
Enabling Canary Deploys requires the ability to create CloudWatch Alarms. This PR doesn't lock down CloudWatch Alarm types too tightly since 1. there aren't many ways to do so and 2. I can't see how they would be a problem.

**How has it been tested?**
In development, and locally

**Change management**
type=routine
risk=low
impact=sev5