### PR TITLE
[Feature] Set env tag in the Fenrir release

### DIFF
--- a/deployer/release.go
+++ b/deployer/release.go
@@ -52,6 +52,8 @@ type Release struct {
 	LogSummary *string `json:"log_summary,omitempty"`
 
 	Outputs map[string]string `json:"outputs,omitempty"`
+
+	Env string `json:"env,omitempty"`
 }
 
 //////////
@@ -240,7 +242,7 @@ func (release *Release) CreateChangeSetInput() (*cloudformation.CreateChangeSetI
 		return nil, err
 	}
 
-	return &cloudformation.CreateChangeSetInput{
+	changeSetInput := &cloudformation.CreateChangeSetInput{
 		ChangeSetName: release.ChangeSetName,
 		ClientToken:   release.ReleaseID,
 		Description:   to.Strp("Fenrir deploy"),
@@ -254,7 +256,13 @@ func (release *Release) CreateChangeSetInput() (*cloudformation.CreateChangeSetI
 		},
 
 		TemplateBody: to.Strp(string(templateBody)),
-	}, nil
+	}
+
+	if release.Env != "" {
+		changeSetInput.Tags = append(changeSetInput.Tags, &cloudformation.Tag{Key: to.Strp("Env"), Value: to.Strp(release.Env)})
+	}
+
+	return changeSetInput, nil
 }
 
 // FetchChangeSet returns two errors (normal error, halt error)

--- a/deployer/release_test.go
+++ b/deployer/release_test.go
@@ -29,3 +29,24 @@ func Test_Release_Cleanup(t *testing.T) {
 
 	assert.True(t, awsc.CFClient.DeleteStackCalled)
 }
+
+func Test_Release_CreateChangeSetInput(t *testing.T) {
+	t.Run("tags", func(t *testing.T) {
+		release, err := MockRelease("../examples/tests/allowed/function.yml")
+		assert.NoError(t, err)
+
+		release.Env = "test-env"
+
+		input, err := release.CreateChangeSetInput()
+		assert.NoError(t, err)
+
+		tags := make(map[string]string)
+		for _, t := range input.Tags {
+			tags[*t.Key] = *t.Value
+		}
+
+		assert.Equal(t, "test-env", tags["Env"])
+		assert.Equal(t, "project", tags["ProjectName"])
+		assert.Equal(t, "development", tags["ConfigName"])
+	})
+}


### PR DESCRIPTION
<!-- Title types: feature | fix | refactor | chore | bug | upgrade | docs -->

**What changed? Why?**
Datadog needs an `Env` tag with a value in order to properly tag APM traces and other metrics with the right tags. 

**How has it been tested?**
Deployed a function and observed the tags set properly.

**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev4 <!-- sev1 sev2 sev3 sev4 sev5 -->