### PR TITLE
[Feature] custom change set tags

### DIFF
--- a/deployer/release_test.go
+++ b/deployer/release_test.go
@@ -30,12 +30,13 @@ func Test_Release_Cleanup(t *testing.T) {
 	assert.True(t, awsc.CFClient.DeleteStackCalled)
 }
 
-func Test_Release_CreateChangeSetInput(t *testing.T) {
+func Test_Release_CreateChangeSetInput_Tags(t *testing.T) {
 	t.Run("tags", func(t *testing.T) {
 		release, err := MockRelease("../examples/tests/allowed/function.yml")
-		assert.NoError(t, err)
-
+		release.ChangeSetTags = map[string]string{"CustomTag": "TTTAG"}
 		release.Env = "test-env"
+		release.SetDefaults(to.Strp("region"), to.Strp("account"))
+		assert.NoError(t, err)
 
 		input, err := release.CreateChangeSetInput()
 		assert.NoError(t, err)
@@ -48,5 +49,6 @@ func Test_Release_CreateChangeSetInput(t *testing.T) {
 		assert.Equal(t, "test-env", tags["Env"])
 		assert.Equal(t, "project", tags["ProjectName"])
 		assert.Equal(t, "development", tags["ConfigName"])
+		assert.Equal(t, "TTTAG", tags["CustomTag"])
 	})
 }

--- a/deployer/release_test.go
+++ b/deployer/release_test.go
@@ -33,7 +33,10 @@ func Test_Release_Cleanup(t *testing.T) {
 func Test_Release_CreateChangeSetInput_Tags(t *testing.T) {
 	t.Run("tags", func(t *testing.T) {
 		release, err := MockRelease("../examples/tests/allowed/function.yml")
-		release.ChangeSetTags = map[string]string{"CustomTag": "TTTAG"}
+		release.ChangeSetTags = map[string]string{
+			"CustomTag":   "TTTAG",
+			"ProjectName": "SHOULD_NOT_OVERRIDE",
+		}
 		release.Env = "test-env"
 		release.SetDefaults(to.Strp("region"), to.Strp("account"))
 		assert.NoError(t, err)


### PR DESCRIPTION
<!-- Title types: feature | fix | refactor | chore | bug | upgrade | docs -->

**What changed? Why?**
Allowing for custom change set tags. This would deprecate the Env value as it is more generic.

**How has it been tested?**
locally

**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev1 sev2 sev3 sev4 sev5 -->