### PR TITLE
[chore] support cloudwatch event trigger

### DIFF
--- a/deployer/template/aws_lambda_permission.go
+++ b/deployer/template/aws_lambda_permission.go
@@ -18,6 +18,7 @@ func ValidateAWSLambdaPermission(
 		"elasticloadbalancing.amazonaws.com",
 		"secretsmanager.amazonaws.com",
 		"apigateway.amazonaws.com",
+		"events.amazonaws.com",
 	}
 
 	if !(inSlice(res.Principal, allowedPrincipals)) {


### PR DESCRIPTION
<!-- Title types: feature | fix | refactor | chore | bug | upgrade | docs -->

**What changed? Why?**
* support cloudwatch events as a lambda trigger

I need this because apparently when you manually create the cloudwatch trigger, it auto makes that lambda policy. but when i did it in prod, it didn't work. so lets add support for SAM to add that trigger

**How has it been tested?**
it hasn't - we've made similar config changes in the past

**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev1 sev2 sev3 sev4 sev5 -->