### PR TITLE
[Fix] allow methodsettings to be defined

### DIFF
--- a/examples/tests/allowed/api_method_settings.yml
+++ b/examples/tests/allowed/api_method_settings.yml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  helloAPI:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: dev
+      MethodSettings:
+        - ThrottlingBurstLimit: 20000
+          ThrottlingRateLimit: 40000

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,8 @@ require (
 	github.com/xeipuuv/gojsonschema v1.1.0
 )
 
-// TODO replace once PR is merged
+// This replaces goformation with a fork that has the fix on it
+// TODO replace once PR https://github.com/awslabs/goformation/pull/243 is merged
 replace github.com/awslabs/goformation/v3 v3.0.0 => github.com/grahamjenson/goformation/v3 v3.0.0-20191105231909-547d63e1fd68
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.1.0
 )
 
-# TODO replace once PR is merged
+// TODO replace once PR is merged
 replace github.com/awslabs/goformation/v3 v3.0.0 => github.com/grahamjenson/goformation/v3 v3.0.0-20191105231909-547d63e1fd68
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.1.0
 )
 
+# TODO replace once PR is merged
+replace github.com/awslabs/goformation/v3 v3.0.0 => github.com/grahamjenson/goformation/v3 v3.0.0-20191105231909-547d63e1fd68
+
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
+github.com/grahamjenson/goformation/v3 v3.0.0-20191105231909-547d63e1fd68 h1:/ttseSjHRaDU4j+Gig55fZu5QWbyQD40B07G8SwbkPs=
+github.com/grahamjenson/goformation/v3 v3.0.0-20191105231909-547d63e1fd68/go.mod h1:hQ5RXo3GNm2laHWKizDzU5DsDy+yNcenSca2UxN0850=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=


### PR DESCRIPTION
<!-- Title types: feature | fix | refactor | chore | bug | upgrade | docs -->

**What changed? Why?**
updating the version of go-formation to a fork that fixes the MethodSettings

**How has it been tested?**
dev

**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev1 sev2 sev3 sev4 sev5 -->