### PR TITLE
[fix] Validate using lambda (fenrir) region not the release region

### DIFF
--- a/deployer/handlers.go
+++ b/deployer/handlers.go
@@ -26,12 +26,12 @@ func Validate(awsc aws.Clients) DeployHandler {
 		release.ReleaseSHA256 = to.SHA256Struct(release)
 
 		// Default the releases Account and Region to where the Lambda is running
-		region, account := to.AwsRegionAccountFromContext(ctx)
+		lambdaRegion, lambdaAccount := to.AwsRegionAccountFromContext(ctx)
 
 		// Fill in all the blank Attributes
-		release.SetDefaults(region, account)
+		release.SetDefaults(lambdaRegion, lambdaAccount)
 
-		if err := release.Validate(awsc.S3(release.AwsRegion, nil, nil)); err != nil {
+		if err := release.Validate(awsc.S3(lambdaRegion, nil, nil)); err != nil {
 			return nil, &errors.BadReleaseError{err.Error()}
 		}
 

--- a/deployer/handlers.go
+++ b/deployer/handlers.go
@@ -57,8 +57,9 @@ func Validate(awsc aws.Clients) DeployHandler {
 // Lock secures a lock for the release
 func Lock(awsc aws.Clients) interface{} {
 	return func(ctx context.Context, release *Release) (*Release, error) {
+		lambdaRegion, _ := to.AwsRegionAccountFromContext(ctx)
 		// returns LockExistsError, LockError
-		return release, release.GrabLocks(awsc.S3(release.AwsRegion, nil, nil))
+		return release, release.GrabLocks(awsc.S3(lambdaRegion, nil, nil))
 	}
 }
 
@@ -103,9 +104,10 @@ func Execute(awsc aws.Clients) DeployHandler {
 
 // ReleaseLock releases lock with sucess
 func ReleaseLock(awsc aws.Clients) DeployHandler {
-	return func(_ context.Context, release *Release) (*Release, error) {
+	return func(ctx context.Context, release *Release) (*Release, error) {
+		lambdaRegion, _ := to.AwsRegionAccountFromContext(ctx)
 
-		if err := release.UnlockRoot(awsc.S3(release.AwsRegion, nil, nil)); err != nil {
+		if err := release.UnlockRoot(awsc.S3(lambdaRegion, nil, nil)); err != nil {
 			return nil, &errors.LockError{err.Error()}
 		}
 


### PR DESCRIPTION
The release is uploaded to the fenrir region (usually us-east-1), but
we're trying to validate using the release's region, which is not
always the same

<!-- Title types: feature | fix | refactor | chore | bug | upgrade | docs -->

**What changed? Why?**
Had errors deploying fenrir projects to non us-east-1 regions

**How has it been tested?**
haven't been able to as no development accounts in eu-west are deployable from dev :(

**Change management**
type=routine
risk=low
impact=sev5
