### PR TITLE
[chore] Bump Goformation to v 4.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/fenrir
 require (
 	github.com/aws/aws-lambda-go v1.17.0
 	github.com/aws/aws-sdk-go v1.31.9
-	github.com/awslabs/goformation/v4 v4.8.0
+	github.com/awslabs/goformation/v4 v4.12.0
 	github.com/coinbase/step v1.0.2
 	github.com/imdario/mergo v0.3.9 // indirect
 	github.com/rogpeppe/godef v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/awslabs/goformation/v4 v4.6.0 h1:5Dy1ZW4ruMlYlq6+PsSCEwW2w00wv7mkFr00
 github.com/awslabs/goformation/v4 v4.6.0/go.mod h1:MBDN7u1lMNDoehbFuO4uPvgwPeolTMA2TzX1yO6KlxI=
 github.com/awslabs/goformation/v4 v4.8.0 h1:UiUhyokRy3suEqBXTnipvY8klqY3Eyl4GCH17brraEc=
 github.com/awslabs/goformation/v4 v4.8.0/go.mod h1:GcJULxCJfloT+3pbqCluXftdEK2AD/UqpS3hkaaBntg=
+github.com/awslabs/goformation/v4 v4.12.0 h1:1imvz5ml178AMp5JkoXrkUWTilow4OoOCHFRD+is/i4=
+github.com/awslabs/goformation/v4 v4.12.0/go.mod h1:GcJULxCJfloT+3pbqCluXftdEK2AD/UqpS3hkaaBntg=
 github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=


### PR DESCRIPTION
**What changed? Why?**
4.12.0 introduces new DynamoDB Event Source Mapping options, such as
support for `MaximumRetryAttempts`, `OnFailure` destinations, etc.

I've already bumped the goformation version in the monorepo, but hadn't noticed that these new settings
were being dropped by the Fenrir validation handler since Fenrir was using this more outdated version.

See here for an example: https://console.aws.amazon.com/states/home?region=us-east-1#/executions/details/arn:aws:states:us-east-1:458004363825:execution:infra-fenrir:mono-repo-users-directory-development-2020-08-12T13-55-05Z-sGuJjed, where the MaximumRetryAttempts are in the Validate input payload, but disappear from the output.

**How has it been tested?**
Specs

**Change management**
type=routine<!-- routine nonroutine emergency -->
risk=low<!-- low medium high -->
impact=sev3<!-- sev1 sev2 sev3 sev4 sev5 -->